### PR TITLE
TriggerLib: Interval trigger does not write log

### DIFF
--- a/src/lib/system/trigger.ts
+++ b/src/lib/system/trigger.ts
@@ -84,11 +84,9 @@ export class Trigger extends EventEmitter {
         try {
             const t = PersistanceManager.fromString(triggerDef);
             this._triggers[name] = triggerDef;
-
-            const job = await t.register(name);
-            this._job[name] = job;
-
             await this.saveConfig();
+
+            this.rescheduleJobs();
             return true;
         } catch (e) {
             return false;


### PR DESCRIPTION
The behavior was because a inconsistent adding of the jobs.

Now the jobs are rescheduled after they are added.

Fixes #24